### PR TITLE
Add GitHub Actions workflow to build cross-platform installers on release

### DIFF
--- a/.github/workflows/release-installers.yml
+++ b/.github/workflows/release-installers.yml
@@ -1,0 +1,195 @@
+name: Release Installers
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  build:
+    name: Build ${{ matrix.os-name }} installer
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            os-name: Linux
+          - os: windows-latest
+            os-name: Windows
+          - os: macos-latest
+            os-name: macOS
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install app dependencies
+        run: uv sync
+
+      - name: Install PyInstaller
+        run: uv pip install pyinstaller pillow
+
+      - name: Install Qt system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            fuse \
+            libfuse2 \
+            libgl1 \
+            libglib2.0-0 \
+            libdbus-1-3 \
+            libegl1 \
+            libxcb-cursor0 \
+            libxcb-icccm4 \
+            libxcb-image0 \
+            libxcb-keysyms1 \
+            libxcb-randr0 \
+            libxcb-render-util0 \
+            libxcb-shape0 \
+            libxcb-xinerama0 \
+            libxcb-xkb1 \
+            libxkbcommon-x11-0
+
+      - name: Build executable (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: |
+          uv run pyinstaller \
+            --name ClockingApp \
+            --onefile \
+            --windowed \
+            --icon clock.png \
+            --add-data "clock.png:." \
+            app.py
+
+      - name: Build executable (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          uv run pyinstaller `
+            --name ClockingApp `
+            --onefile `
+            --windowed `
+            --icon clock.png `
+            --add-data "clock.png;." `
+            app.py
+
+      # ── Linux: package as AppImage ─────────────────────────────────────────
+      - name: Create AppImage (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          wget -q \
+            "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" \
+            -O appimagetool
+          chmod +x appimagetool
+
+          mkdir -p AppDir/usr/bin
+          cp dist/ClockingApp AppDir/usr/bin/ClockingApp
+          cp clock.png AppDir/ClockingApp.png
+
+          cat > AppDir/AppRun << 'EOF'
+          #!/bin/bash
+          exec "$(dirname "$(readlink -f "$0")")/usr/bin/ClockingApp" "$@"
+          EOF
+          chmod +x AppDir/AppRun
+
+          cat > AppDir/ClockingApp.desktop << 'EOF'
+          [Desktop Entry]
+          Name=ClockingApp
+          Exec=ClockingApp
+          Icon=ClockingApp
+          Type=Application
+          Categories=Utility;
+          EOF
+
+          ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 \
+            ./appimagetool AppDir ClockingApp-linux-x86_64.AppImage
+
+      # ── macOS: package as DMG ──────────────────────────────────────────────
+      - name: Create DMG (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          mkdir -p dmg-staging
+          cp -r dist/ClockingApp.app dmg-staging/
+          ln -s /Applications dmg-staging/Applications
+          hdiutil create \
+            -volname "ClockingApp" \
+            -srcfolder dmg-staging \
+            -ov \
+            -format UDZO \
+            ClockingApp-macos.dmg
+
+      # ── Windows: package as NSIS installer ────────────────────────────────
+      - name: Create NSIS installer (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $nsis = @"
+          Unicode true
+          !define APP_NAME "ClockingApp"
+
+          Name "`${APP_NAME}"
+          OutFile "ClockingApp-windows-setup.exe"
+          InstallDir "`$PROGRAMFILES64\ClockingApp"
+          InstallDirRegKey HKLM "Software\ClockingApp" "InstallDir"
+          RequestExecutionLevel admin
+
+          Section "Install"
+            SetOutPath "`$INSTDIR"
+            File "dist\ClockingApp.exe"
+            WriteUninstaller "`$INSTDIR\Uninstall.exe"
+            CreateShortcut "`$DESKTOP\ClockingApp.lnk" "`$INSTDIR\ClockingApp.exe"
+            CreateDirectory "`$SMPROGRAMS\ClockingApp"
+            CreateShortcut "`$SMPROGRAMS\ClockingApp\ClockingApp.lnk" "`$INSTDIR\ClockingApp.exe"
+            CreateShortcut "`$SMPROGRAMS\ClockingApp\Uninstall.lnk" "`$INSTDIR\Uninstall.exe"
+            WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ClockingApp" \
+              "DisplayName" "`${APP_NAME}"
+            WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ClockingApp" \
+              "UninstallString" "`$INSTDIR\Uninstall.exe"
+          SectionEnd
+
+          Section "Uninstall"
+            Delete "`$INSTDIR\ClockingApp.exe"
+            Delete "`$INSTDIR\Uninstall.exe"
+            Delete "`$DESKTOP\ClockingApp.lnk"
+            Delete "`$SMPROGRAMS\ClockingApp\ClockingApp.lnk"
+            Delete "`$SMPROGRAMS\ClockingApp\Uninstall.lnk"
+            RMDir "`$SMPROGRAMS\ClockingApp"
+            RMDir "`$INSTDIR"
+            DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\ClockingApp"
+            DeleteRegKey HKLM "Software\ClockingApp"
+          SectionEnd
+          "@
+          $nsis | Out-File -FilePath installer.nsi -Encoding ASCII
+          makensis installer.nsi
+
+      # ── Upload artifacts ───────────────────────────────────────────────────
+      - name: Upload Linux AppImage
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ClockingApp-linux
+          path: ClockingApp-linux-x86_64.AppImage
+
+      - name: Upload macOS DMG
+        if: runner.os == 'macOS'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ClockingApp-macos
+          path: ClockingApp-macos.dmg
+
+      - name: Upload Windows installer
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ClockingApp-windows
+          path: ClockingApp-windows-setup.exe


### PR DESCRIPTION
Triggers on push to the release branch and builds in parallel:
- Linux: standalone binary packaged as AppImage (x86_64)
- macOS: PyInstaller .app bundle wrapped in a DMG
- Windows: single .exe built with PyInstaller, wrapped in an NSIS installer

https://claude.ai/code/session_01L9RZ8mjcBfvDckzCvm2Sof