### PR TITLE
Add worklog update support for Jira and Clockify

### DIFF
--- a/services/clockify_api.py
+++ b/services/clockify_api.py
@@ -79,7 +79,7 @@ def log_time_in_clockify(
     task_key: str,
     start_time: datetime,
     end_time: datetime,
-) -> bool:
+) -> str | None:
     config = _get_config()
     url = f'{config.url}/{config.workspace}/time-entries'
     data = {
@@ -90,8 +90,37 @@ def log_time_in_clockify(
         'projectId': project_id,
         'taskId': task_id,
     }
-    response = requests.post(url, json=data, headers=config.headers)    
-    return response.ok
+    response = requests.post(url, json=data, headers=config.headers)
+    return response.json().get('id') if response.ok else None
+
+
+def update_time_entry_in_clockify(
+    entry_id: str,
+    task_key: str,
+    start_time: datetime,
+    end_time: datetime,
+) -> bool:
+    try:
+        config = _get_config()
+        project_key = task_key.split('-')[0]
+        project_name = get_project_name(project_key)
+        project_id = find_clockify_project(project_name)
+        task_id = find_or_create_clockify_task(project_id, task_key)
+
+        url = f'{config.url}/{config.workspace}/time-entries/{entry_id}'
+        data = {
+            'start': convert_datetime_to_utc(start_time),
+            'end': convert_datetime_to_utc(end_time),
+            'billable': True,
+            'description': task_key,
+            'projectId': project_id,
+            'taskId': task_id,
+        }
+        response = requests.put(url, json=data, headers=config.headers)
+        return response.ok
+    except Exception as e:
+        print(f"Error updating Clockify entry: {e}")
+    return False
 
 
 def clear_clockify_cache() -> None:
@@ -104,7 +133,7 @@ def push_worklog_to_clockify(
     task_key: str,
     start_time: datetime,
     end_time: datetime,
-) -> bool:
+) -> str | None:
 
     try:
         project_key = task_key.split('-')[0]
@@ -113,6 +142,6 @@ def push_worklog_to_clockify(
 
         task_id = find_or_create_clockify_task(project_id, task_key)
     except ClockingException:
-        return False
+        return None
 
     return log_time_in_clockify(project_id, task_id, task_key, start_time, end_time)

--- a/services/database.py
+++ b/services/database.py
@@ -18,6 +18,8 @@ class ClockingRecord:
     check_out: str | None    # YYYY-MM-DD HH:MM or None
     message: str | None
     id: int | None = None
+    jira_worklog_id: str | None = None
+    clockify_entry_id: str | None = None
 
     @property
     def check_in_time(self) -> str:
@@ -81,6 +83,8 @@ def _clocking_from_row(row: sqlite3.Row) -> ClockingRecord:
         check_in=row['check_in'],
         check_out=row['check_out'],
         message=row['message'],
+        jira_worklog_id=row['jira_worklog_id'],
+        clockify_entry_id=row['clockify_entry_id'],
     )
 
 
@@ -103,6 +107,15 @@ def _task_duration_from_row(row: sqlite3.Row) -> TaskDuration:
 # Schema initialisation
 # ---------------------------------------------------------------------------
 
+def _migrate_db() -> None:
+    with _get_connection() as conn:
+        for col in ("jira_worklog_id", "clockify_entry_id"):
+            try:
+                conn.execute(f"ALTER TABLE clockings ADD COLUMN {col} TEXT")
+            except sqlite3.OperationalError:
+                pass  # column already exists
+
+
 def init_db() -> None:
     """Create tables if they do not yet exist."""
     with _get_connection() as conn:
@@ -123,6 +136,7 @@ def init_db() -> None:
                     CHECK(task_type IN ('fixed', 'open', 'closed'))
             );
         """)
+    _migrate_db()
 
 
 # ---------------------------------------------------------------------------
@@ -133,7 +147,7 @@ def get_all_clockings() -> list[ClockingRecord]:
     """Return all clocking rows ordered by check_in."""
     with _get_connection() as conn:
         rows = conn.execute(
-            "SELECT id, date, task, check_in, check_out, message "
+            "SELECT id, date, task, check_in, check_out, message, jira_worklog_id, clockify_entry_id "
             "FROM clockings ORDER BY check_in"
         ).fetchall()
     return [_clocking_from_row(r) for r in rows]
@@ -143,7 +157,7 @@ def get_clockings_for_date(date: str) -> list[ClockingRecord]:
     """Return completed clocking rows for a given date (YYYY-MM-DD)."""
     with _get_connection() as conn:
         rows = conn.execute(
-            "SELECT id, date, task, check_in, check_out, message "
+            "SELECT id, date, task, check_in, check_out, message, jira_worklog_id, clockify_entry_id "
             "FROM clockings WHERE date = ? AND check_out IS NOT NULL "
             "ORDER BY check_in",
             (date,),
@@ -155,7 +169,7 @@ def get_open_clocking() -> ClockingRecord | None:
     """Return the clocking row with no check_out (the active session), or None."""
     with _get_connection() as conn:
         row = conn.execute(
-            "SELECT id, date, task, check_in, check_out, message "
+            "SELECT id, date, task, check_in, check_out, message, jira_worklog_id, clockify_entry_id "
             "FROM clockings WHERE check_out IS NULL ORDER BY id DESC LIMIT 1"
         ).fetchone()
     return _clocking_from_row(row) if row else None
@@ -208,19 +222,46 @@ def update_check_out(row_id: int, check_out: str) -> None:
         )
 
 
+def update_jira_worklog_id(row_id: int, jira_worklog_id: str) -> None:
+    """Persist the Jira worklog ID returned after a successful push."""
+    with _get_connection() as conn:
+        conn.execute(
+            "UPDATE clockings SET jira_worklog_id = ? WHERE id = ?",
+            (jira_worklog_id, row_id),
+        )
+
+
+def update_clockify_entry_id(row_id: int, clockify_entry_id: str) -> None:
+    """Persist the Clockify time entry ID returned after a successful push."""
+    with _get_connection() as conn:
+        conn.execute(
+            "UPDATE clockings SET clockify_entry_id = ? WHERE id = ?",
+            (clockify_entry_id, row_id),
+        )
+
+
 def upsert_clocking(record: ClockingRecord) -> int:
     """Insert or update a single clocking row. Returns the row id."""
     with _get_connection() as conn:
         if record.id:
-            conn.execute(
-                "UPDATE clockings SET date=?, task=?, check_in=?, check_out=?, message=? WHERE id=?",
-                (record.date, record.task, record.check_in, record.check_out, record.message, record.id),
-            )
+            fields = "date=?, task=?, check_in=?, check_out=?, message=?"
+            params: list = [record.date, record.task, record.check_in,
+                            record.check_out, record.message]
+            if record.jira_worklog_id is not None:
+                fields += ", jira_worklog_id=?"
+                params.append(record.jira_worklog_id)
+            if record.clockify_entry_id is not None:
+                fields += ", clockify_entry_id=?"
+                params.append(record.clockify_entry_id)
+            params.append(record.id)
+            conn.execute(f"UPDATE clockings SET {fields} WHERE id=?", params)
             return record.id
         else:
             cursor = conn.execute(
-                "INSERT INTO clockings (date, task, check_in, check_out, message) VALUES (?, ?, ?, ?, ?)",
-                (record.date, record.task, record.check_in, record.check_out, record.message),
+                "INSERT INTO clockings (date, task, check_in, check_out, message, jira_worklog_id, clockify_entry_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (record.date, record.task, record.check_in, record.check_out,
+                 record.message, record.jira_worklog_id, record.clockify_entry_id),
             )
             return cursor.lastrowid if cursor.lastrowid is not None else 0
 
@@ -235,10 +276,11 @@ def save_clockings(records: list[ClockingRecord]) -> None:
     """Replace the entire clockings table with the supplied records."""
     with _get_connection() as conn:
         conn.executemany(
-            "INSERT INTO clockings (id, date, task, check_in, check_out, message) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO clockings (id, date, task, check_in, check_out, message, jira_worklog_id, clockify_entry_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             [
-                (r.id, r.date, r.task, r.check_in, r.check_out, r.message)
+                (r.id, r.date, r.task, r.check_in, r.check_out, r.message,
+                 r.jira_worklog_id, r.clockify_entry_id)
                 for r in records
             ],
         )

--- a/services/jira_api.py
+++ b/services/jira_api.py
@@ -32,16 +32,32 @@ def clear_jira_cache() -> None:
     get_project_name.cache_clear()
 
 
-def push_worklog_to_jira(issue_key: str, start_datetime: datetime.datetime, duration: datetime.timedelta) -> bool:
+def push_worklog_to_jira(issue_key: str, start_datetime: datetime.datetime, duration: datetime.timedelta) -> str | None:
     try:
         t = int(duration.total_seconds())
-        timeSpent = str(t)
-
-        get_jira().add_worklog(issue_key, timeSpentSeconds=timeSpent, started=start_datetime)
-        return True
+        worklog = get_jira().add_worklog(issue_key, timeSpentSeconds=str(t), started=start_datetime)
+        return worklog.id
     except Exception as e:
         print(f"Error pushing worklog to Jira: {e}")
+    return None
 
+
+def update_worklog_in_jira(
+    issue_key: str,
+    worklog_id: str,
+    start_datetime: datetime.datetime,
+    duration: datetime.timedelta,
+) -> bool:
+    try:
+        t = int(duration.total_seconds())
+        worklog = get_jira().worklog(issue_key, worklog_id)
+        worklog.update(fields={
+            "timeSpentSeconds": t,
+            "started": start_datetime.strftime("%Y-%m-%dT%H:%M:%S.000+0000"),
+        })
+        return True
+    except Exception as e:
+        print(f"Error updating worklog in Jira: {e}")
     return False
 
 

--- a/tests/test_clocking_summary.py
+++ b/tests/test_clocking_summary.py
@@ -219,6 +219,7 @@ class TestPushToJira:
         import windows.clocking_summary as cs
         monkeypatch.setattr(cs, 'get_config_manager', lambda: mock_config)
         monkeypatch.setattr(cs, 'get_task_durations_for_date', lambda d: [])
+        monkeypatch.setattr(cs, 'update_jira_worklog_id', lambda row_id, wl_id: None)
 
         records = [
             make_record(TODAY_STR, 'TASK-1', '09:00', '10:00'),
@@ -228,7 +229,7 @@ class TestPushToJira:
 
         push_calls = []
         monkeypatch.setattr(cs, 'push_worklog_to_jira',
-                            lambda task, start, duration: push_calls.append(task) or True)
+                            lambda task, start, duration: push_calls.append(task) or 'wl-id')
 
         widget = ClockingSummary([])
         widget.push_to_jira(TODAY_STR)
@@ -247,7 +248,7 @@ class TestPushToJira:
 
         push_calls = []
         monkeypatch.setattr(cs, 'push_worklog_to_jira',
-                            lambda task, start, duration: push_calls.append(task) or True)
+                            lambda task, start, duration: push_calls.append(task) or 'wl-id')
 
         widget = ClockingSummary([])
         widget.push_to_jira(TODAY_STR)
@@ -260,6 +261,7 @@ class TestPushToJira:
         import windows.clocking_summary as cs
         monkeypatch.setattr(cs, 'get_config_manager', lambda: mock_config)
         monkeypatch.setattr(cs, 'get_task_durations_for_date', lambda d: [])
+        monkeypatch.setattr(cs, 'update_jira_worklog_id', lambda row_id, wl_id: None)
 
         records = [
             make_record(TODAY_STR, 'TASK-1', '09:00', '10:00'),
@@ -267,7 +269,7 @@ class TestPushToJira:
         ]
         monkeypatch.setattr(cs, 'get_clockings_for_date', lambda d: records)
 
-        results = iter([True, False])
+        results = iter(['wl-id-1', None])
         monkeypatch.setattr(cs, 'push_worklog_to_jira',
                             lambda task, start, duration: next(results))
 
@@ -276,6 +278,51 @@ class TestPushToJira:
         log = widget.log_text.toHtml()
         assert 'Success' in log
         assert 'Fail' in log
+        widget.close()
+
+    def test_calls_update_when_jira_worklog_id_exists(self, qt_app, monkeypatch):
+        mock_config = MagicMock()
+        mock_config.is_jira_configured.return_value = (True, [])
+        import windows.clocking_summary as cs
+        monkeypatch.setattr(cs, 'get_config_manager', lambda: mock_config)
+        monkeypatch.setattr(cs, 'get_task_durations_for_date', lambda d: [])
+
+        record = make_record(TODAY_STR, 'TASK-1', '09:00', '10:00', id=1)
+        record.jira_worklog_id = 'existing-wl-99'
+        monkeypatch.setattr(cs, 'get_clockings_for_date', lambda d: [record])
+
+        update_calls = []
+        monkeypatch.setattr(cs, 'update_worklog_in_jira',
+                            lambda task, wl_id, start, dur: update_calls.append((task, wl_id)) or True)
+        create_calls = []
+        monkeypatch.setattr(cs, 'push_worklog_to_jira',
+                            lambda task, start, dur: create_calls.append(task) or 'new-id')
+
+        widget = ClockingSummary([])
+        widget.push_to_jira(TODAY_STR)
+        assert update_calls == [('TASK-1', 'existing-wl-99')]
+        assert create_calls == []
+        widget.close()
+
+    def test_saves_jira_worklog_id_after_create(self, qt_app, monkeypatch):
+        mock_config = MagicMock()
+        mock_config.is_jira_configured.return_value = (True, [])
+        import windows.clocking_summary as cs
+        monkeypatch.setattr(cs, 'get_config_manager', lambda: mock_config)
+        monkeypatch.setattr(cs, 'get_task_durations_for_date', lambda d: [])
+
+        record = make_record(TODAY_STR, 'TASK-1', '09:00', '10:00', id=42)
+        monkeypatch.setattr(cs, 'get_clockings_for_date', lambda d: [record])
+        monkeypatch.setattr(cs, 'push_worklog_to_jira',
+                            lambda task, start, dur: 'new-worklog-id')
+
+        saved = {}
+        monkeypatch.setattr(cs, 'update_jira_worklog_id',
+                            lambda row_id, wl_id: saved.update({row_id: wl_id}))
+
+        widget = ClockingSummary([])
+        widget.push_to_jira(TODAY_STR)
+        assert saved == {42: 'new-worklog-id'}
         widget.close()
 
 
@@ -304,6 +351,7 @@ class TestPushToClockify:
         import windows.clocking_summary as cs
         monkeypatch.setattr(cs, 'get_config_manager', lambda: mock_config)
         monkeypatch.setattr(cs, 'get_task_durations_for_date', lambda d: [])
+        monkeypatch.setattr(cs, 'update_clockify_entry_id', lambda row_id, eid: None)
 
         records = [
             make_record(TODAY_STR, 'TASK-1', '09:00', '10:00'),
@@ -313,7 +361,7 @@ class TestPushToClockify:
 
         push_calls = []
         monkeypatch.setattr(cs, 'push_worklog_to_clockify',
-                            lambda task, start, end: push_calls.append(task) or True)
+                            lambda task, start, end: push_calls.append(task) or 'entry-id')
 
         widget = ClockingSummary([])
         widget.push_to_clockify(TODAY_STR)
@@ -330,9 +378,54 @@ class TestPushToClockify:
 
         push_calls = []
         monkeypatch.setattr(cs, 'push_worklog_to_clockify',
-                            lambda task, start, end: push_calls.append(task) or True)
+                            lambda task, start, end: push_calls.append(task) or 'entry-id')
 
         widget = ClockingSummary([])
         widget.push_to_clockify(TODAY_STR)
         assert push_calls == []
+        widget.close()
+
+    def test_calls_update_when_clockify_entry_id_exists(self, qt_app, monkeypatch):
+        mock_config = MagicMock()
+        mock_config.is_clockify_configured.return_value = (True, [])
+        import windows.clocking_summary as cs
+        monkeypatch.setattr(cs, 'get_config_manager', lambda: mock_config)
+        monkeypatch.setattr(cs, 'get_task_durations_for_date', lambda d: [])
+
+        record = make_record(TODAY_STR, 'TASK-1', '09:00', '10:00', id=1)
+        record.clockify_entry_id = 'existing-entry-99'
+        monkeypatch.setattr(cs, 'get_clockings_for_date', lambda d: [record])
+
+        update_calls = []
+        monkeypatch.setattr(cs, 'update_time_entry_in_clockify',
+                            lambda eid, task, start, end: update_calls.append((eid, task)) or True)
+        create_calls = []
+        monkeypatch.setattr(cs, 'push_worklog_to_clockify',
+                            lambda task, start, end: create_calls.append(task) or 'new-id')
+
+        widget = ClockingSummary([])
+        widget.push_to_clockify(TODAY_STR)
+        assert update_calls == [('existing-entry-99', 'TASK-1')]
+        assert create_calls == []
+        widget.close()
+
+    def test_saves_clockify_entry_id_after_create(self, qt_app, monkeypatch):
+        mock_config = MagicMock()
+        mock_config.is_clockify_configured.return_value = (True, [])
+        import windows.clocking_summary as cs
+        monkeypatch.setattr(cs, 'get_config_manager', lambda: mock_config)
+        monkeypatch.setattr(cs, 'get_task_durations_for_date', lambda d: [])
+
+        record = make_record(TODAY_STR, 'TASK-1', '09:00', '10:00', id=55)
+        monkeypatch.setattr(cs, 'get_clockings_for_date', lambda d: [record])
+        monkeypatch.setattr(cs, 'push_worklog_to_clockify',
+                            lambda task, start, end: 'new-entry-id')
+
+        saved = {}
+        monkeypatch.setattr(cs, 'update_clockify_entry_id',
+                            lambda row_id, eid: saved.update({row_id: eid}))
+
+        widget = ClockingSummary([])
+        widget.push_to_clockify(TODAY_STR)
+        assert saved == {55: 'new-entry-id'}
         widget.close()

--- a/uv.lock
+++ b/uv.lock
@@ -123,7 +123,7 @@ wheels = [
 
 [[package]]
 name = "clocking-app"
-version = "0.1.0"
+version = "0.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "jira" },

--- a/windows/clocking_summary.py
+++ b/windows/clocking_summary.py
@@ -4,14 +4,16 @@ from PySide6 import QtGui
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QPushButton, QTextEdit, QVBoxLayout, QWidget
 
-from services.clockify_api import push_worklog_to_clockify
+from services.clockify_api import push_worklog_to_clockify, update_time_entry_in_clockify
 from services.config_manager import get_config_manager
 from services.database import (
     ClockingRecord,
     get_clockings_for_date,
     get_task_durations_for_date,
+    update_clockify_entry_id,
+    update_jira_worklog_id,
 )
-from services.jira_api import push_worklog_to_jira
+from services.jira_api import push_worklog_to_jira, update_worklog_in_jira
 from services.utils import format_timedelta, format_timedelta_jira
 
 _FMT = "%Y-%m-%d %H:%M"
@@ -78,7 +80,13 @@ class ClockingSummary(QWidget):
             duration = check_out_dt - check_in_dt
             start_dt = datetime.datetime(date.year, date.month, date.day,
                                          check_in_dt.hour, check_in_dt.minute)
-            ok = push_worklog_to_jira(r.task, start_dt, duration)
+            if r.jira_worklog_id:
+                ok = update_worklog_in_jira(r.task, r.jira_worklog_id, start_dt, duration)
+            else:
+                worklog_id = push_worklog_to_jira(r.task, start_dt, duration)
+                ok = worklog_id is not None
+                if ok and r.id is not None:
+                    update_jira_worklog_id(r.id, worklog_id)
             self.log_pushing_output(duration, ok, r.task)
 
         self.log_text.append('Done')
@@ -106,7 +114,13 @@ class ClockingSummary(QWidget):
                                          check_in_dt.hour, check_in_dt.minute)
             end_dt = datetime.datetime(date.year, date.month, date.day,
                                        check_out_dt.hour, check_out_dt.minute)
-            ok = push_worklog_to_clockify(r.task, start_dt, end_dt)
+            if r.clockify_entry_id:
+                ok = update_time_entry_in_clockify(r.clockify_entry_id, r.task, start_dt, end_dt)
+            else:
+                entry_id = push_worklog_to_clockify(r.task, start_dt, end_dt)
+                ok = entry_id is not None
+                if ok and r.id is not None:
+                    update_clockify_entry_id(r.id, entry_id)
             self.log_pushing_output(duration, ok, r.task)
 
         self.log_text.append('Done')


### PR DESCRIPTION
Store jira_worklog_id and clockify_entry_id on each clocking record so
that a second push on the same day updates the existing entry instead of
creating a duplicate. Includes DB migration, new update functions in both
API layers, create-vs-update logic in the summary window, and updated tests.

https://claude.ai/code/session_017YRVed6vCKKAkL3NjvsJuc